### PR TITLE
Add conda environment file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,17 +63,26 @@ We have integrated this system with [SpikeInterface](https://github.com/SpikeInt
 [See these instructions](https://github.com/flatironinstitute/kachery-p2p).
 The kachery-p2p tool has been tested on Linux and MacOS.
 
-**Step 2.** Clone and pip-install this repo in development mode (you should use a virtualenv or conda environment):
+**Step 2.** Clone this repo:
 
 ```
 git clone https://github.com/flatironinstitute/neuropixels-data-sep-2020
 cd neuropixels-data-sep-2020
-pip install -e .
 ```
 
+**Step 3.** Create a Conda environment to manage neuropixels-related dependencies, and
+install the neuropixels repository in development mode:
+```
+conda env create -f environment.yml
+conda activate neuropixels-2020
+pip install -e .
+```
 For subsequent updates, run `git pull` and rerun the `pip install -e .`
 
-**Step 3.** Load a recording into a SpikeInterface recording extractor:
+From here on, you should ensure that you run `conda activate neuropixels-2020` before
+trying to use the tools or code from this repository.
+
+**Step 4.** Load a recording into a SpikeInterface recording extractor:
 
 ```python
 # You need to be running the kachery-p2p daemon, flatiron1 channel

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,20 @@
+name: neuropixels-2020
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.8.*
+  - pip=20.1.*
+  - pip:
+    - click
+    - h5py
+    - hither
+    - inquirer
+    - kachery
+    - kachery-p2p
+    - mkl
+    - pynwb
+    - spikeextractors
+  - numpy>=1.19.*
+  - nodejs>=14.7.0
+  - scipy=1.5.*


### PR DESCRIPTION
Adds an `environment.yml` to participant environment setup. I have confirmed that the code on the readme page works with this environment. Participants will still need to execute `pip install -e .` to install the neuropixels package, as I do not believe that's currently distributed from a repo (and in any event it's changing rapidly anyway) and will obviously still need to do the kachery directory setup for kachery-p2p.

My personal neuropixels environment has a couple extra things installed--mainly numpy-base, some mkl packages and blas, as well as pymongo. I think the latter is an outdated dependency from the old version of hither. Not sure about the math libraries--they are not needed to execute the sample code on the readme page, so I'm not too sure how they got there, but I will leave them out until they actually seem to be needed.